### PR TITLE
Add instructions for event weights

### DIFF
--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -274,11 +274,11 @@ The dataset will contain a tag detailing which run you are looking at. We are us
 
 Dataset | Number of Events | Total Luminosity |
 | --- | --- | --- |
-data24_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
-data22_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
-data23_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
-data24_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
-data25_13p6TeV | 3750000000 | 39.3 femto-barns^-1 |
+data24_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
+data22_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
+data23_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
+data24_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
+data25_13p6TeV | 1500000000 | 39.3 femto-barns^-1 |
 
 ### Cross-section Scaling and MC
 

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -255,6 +255,8 @@ Always make sure to tell the user what event weights you are applying. If the ab
 
 If any calculations are required (e.g. cross section times integrated luminosity, etc), do them in the code so the user can update things as they wish.
 
+It is not uncommon for a user to ask for a MC sample to be scaled by x10 or similar. Make sure to put the scale factor in the legend entry for that sample.
+
 ### MC Event Weight
 
 This is encoded on the `EventInfo` object (there is only one), and it is the first `mcEventWeight`:
@@ -264,7 +266,21 @@ query = (FuncADLQueryPHYSLITE()
     .Select(lambda e: e.EventInfo("EventInfo").mcEventWeight(0))
 ```
 
-### Crossection Scaling
+### Data
+
+When including data we need to calculate the luminosity of the data we are including and rescale any MC to that. The proper way is not current available in this system. For now, scale the luminosity for a particular run by the number of events you are looking at (you'll have to count the number of events).
+
+The dataset will contain a tag detailing which run you are looking at. We are using an estimate of the number of events - 10^9 per year.
+
+Dataset | Number of Events | Total Luminosity |
+| --- | --- | --- |
+data24_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
+data22_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
+data23_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
+data24_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
+data25_13p6TeV | 750000000 | 39.3 femto-barns^-1 |
+
+### Cross-section Scaling and MC
 
 Each event in a sample is scaled by a constant scale factor:
 

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -259,11 +259,11 @@ Don't apply any event or sample weights to data unless explicitly requested.
 
 ### MC Event Weight
 
-This is encoded on the `EventInfo` object, and it is the first `mcEventWeight`:
+This is encoded on the `EventInfo` object (there is only one), and it is the first `mcEventWeight`:
 
 ```python
 query = (FuncADLQueryPHYSLITE()
-    .Select(lambda e: e.EventInfo("EventInfo").Select(lambda e: e.mcEventWeight(0)
+    .Select(lambda e: e.EventInfo("EventInfo").mcEventWeight(0))
 ```
 
 ### Crossection Scaling

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -274,7 +274,7 @@ $ sf = $ L * \sigma / N_S $
 
 * $L$ - the target integrated luminosity for the plot. Use 1 femto-barn-1 by default.
 * $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
-* $N_S$ the total number of events in the sample. This must be taken as the total number of events in the file before *any* cuts.
+* $N_S$ the total number of events in the sample. This must be taken as the total number of events in the file before *any* cuts. To do this, you should collect a "1" for every event, and then take the len of the array. See below for an example.
 
 The cross-section table is below, organized by run number and name. Every ATLAS sample is unique by run number, which is in the name of the dataset. For example, "mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697" is an MC dataset with run number 801167 and name Py8EG_A14NNPDF23LO_jj_JZ2 (or JZ2). Data leads with "data..." in the name.
 
@@ -286,4 +286,14 @@ Run Number | Name | Cross Section
 601237 | PhPy8EG_A14_ttbar_hdamp258p75_allhad | 812 pico-barn
 701005 | Sh_2214_lllvjj | 53.1 femto-barn
 
+#### Counting The Sample Size
+
+If you can do something similar to this:
+
+```python
+query = (FuncADLQueryPHYSLITE()
+    .Select(lambda e: 1.0)
+```
+
+And take the `len` of the array when it comes back.
 Make sure to do all calculations in the code; don't do the math in your head. The user may well want to take the code and change some of the parameters.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -280,8 +280,8 @@ The cross-section table is below, organized by run number and name. Every ATLAS 
 
 Run Number | Name | Cross Section
 --- | --- | ---
-801167 | Py8EG_A14NNPDF23LO_jj_JZ2 | 2.58 mili-barn
-801168 | Py8EG_A14NNPDF23LO_jj_JZ3 | 8.6 micro-barn
+801167 | Py8EG_A14NNPDF23LO_jj_JZ2 | 2582600000.0 pico-barn
+801168 | Py8EG_A14NNPDF23LO_jj_JZ3 | 28528000.0 pico-barn
 513109 | MGPy8EG_Zmumu_FxFx3jHT2bias_SW_CFilterBVeto | 2.39 nano-barn
 601237 | PhPy8EG_A14_ttbar_hdamp258p75_allhad | 812 pico-barn
 701005 | Sh_2214_lllvjj | 53.1 femto-barn

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -240,3 +240,15 @@ Usage of `jet_is_tagged` in `func_adl` is straight forward:
 query = (FuncADLQueryPHYSLITE()
     .Select(lambda e: e.Jets().Select(lambda j: jet_is_tagged(j)))
 ```
+
+## Event Weights
+
+Unless otherwise requested by the user, use the following guidelines to determine how to do event weighting:
+
+* **Single MC or Data Dataset**: Apply only the MC event weight.
+
+* **Multiple MC Datasets**: Apply the MC event weights, and the cross section. If the cross section weight isn't available for any one sample, then don't apply it for any samples (and make sure to tell the user you are missing that information). The normal way to plot this is with a stacked histogram.
+
+* **MC and Data*: Apply the MC event weights and the cross section, and scale to the integrated luminosity of the data. The normal way to plot this is to use a stacked histogram and the data as a filled black circles.
+
+Always make sure to tell the user what event weights you are applying.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -274,11 +274,11 @@ The dataset will contain a tag detailing which run you are looking at. We are us
 
 Dataset | Number of Events | Total Luminosity |
 | --- | --- | --- |
-data24_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
-data22_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
-data23_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
-data24_13p6TeV | 1000000000 | 52.4 femto-barns^-1 |
-data25_13p6TeV | 750000000 | 39.3 femto-barns^-1 |
+data24_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
+data22_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
+data23_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
+data24_13p6TeV | 5000000000 | 52.4 femto-barns^-1 |
+data25_13p6TeV | 3750000000 | 39.3 femto-barns^-1 |
 
 ### Cross-section Scaling and MC
 

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -272,7 +272,7 @@ Each event in a sample is scaled by a constant scale factor:
 
 $ sf = $ L * \sigma / N_S $
 
-* $L$ - the target integrated luminosity for the plot. Use 1 fempto-barn-1 by default.
+* $L$ - the target integrated luminosity for the plot. Use 1 femto-barn-1 by default.
 * $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
 * $N_S$ the total number of events in the sample. This must be taken as the total number of events in the file before *any* cuts.
 
@@ -281,8 +281,9 @@ The cross-section table is below, organized by run number and name. Every ATLAS 
 Run Number | Name | Cross Section
 --- | --- | ---
 801167 | Py8EG_A14NNPDF23LO_jj_JZ2 | 2.58 mili-barn
+801168 | Py8EG_A14NNPDF23LO_jj_JZ3 | 8.6 micro-barn
 513109 | MGPy8EG_Zmumu_FxFx3jHT2bias_SW_CFilterBVeto | 2.39 nano-barn
 601237 | PhPy8EG_A14_ttbar_hdamp258p75_allhad | 812 pico-barn
-701005 | Sh_2214_lllvjj | 53.1 fempto-barn
+701005 | Sh_2214_lllvjj | 53.1 femto-barn
 
 Make sure to do all calculations in the code; don't do the math in your head. The user may well want to take the code and change some of the parameters.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -247,15 +247,13 @@ Unless otherwise requested by the user, use the following guidelines to determin
 
 * **Single MC or Data Dataset**: Apply only the MC event weight.
 
-* **Multiple MC Datasets**: Apply the MC event weights, and the cross section scaling. If the cross section values aren't available for any one sample, then don't apply it for any samples (and make sure to tell the user you are missing that information). The normal way to plot this is with a stacked histogram.
+* **Multiple MC Datasets**: Apply the MC event weight and the cross section scaling. If the cross section values aren't available for any one sample, then don't apply it for any samples (and make sure to tell the user in the notes you are missing that information). The normal way to plot this is with a stacked histogram.
 
-* **MC and Data*: Apply the MC event weights and the cross section, and scale to the integrated luminosity of the data. The normal way to plot this is to use a stacked histogram and the data as a filled black circles.
+* **MC and Data**: Apply the MC event weights and the cross section, and scale to the integrated luminosity of the data. The normal way to plot this is to use a stacked histogram and the data as a filled black circles.
 
 Always make sure to tell the user what event weights you are applying. If the above guidance tells you to apply event weights but you don't know how, warn the user.
 
-If any calculations are required (e.g. cross section times integrated luminosity, etc), do them in the code to the user can update things as they wish.
-
-Don't apply any event or sample weights to data unless explicitly requested.
+If any calculations are required (e.g. cross section times integrated luminosity, etc), do them in the code so the user can update things as they wish.
 
 ### MC Event Weight
 
@@ -276,8 +274,6 @@ $ sf = $ L * \sigma / N_S $
 * $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
 * $N_S$ sum of all the per-event weights (the `mcEventWeight(0)` above). This must be taken as the sum over all events in the file - before *any* cuts. Gather the `mcEventWeight(0)` for all events in the file.
 
-For a plot, please place the integrated luminosity you rescaled the MC to (`L=xx $fb^-1$`) somewhere on the plot.
-
 The cross-section table is below, organized by run number and name. Every ATLAS sample is unique by run number, which is in the name of the dataset. For example, "mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697" is an MC dataset with run number 801167 and name Py8EG_A14NNPDF23LO_jj_JZ2 (or JZ2). Data leads with "data..." in the name.
 
 Run Number | Name | Cross Section
@@ -289,3 +285,7 @@ Run Number | Name | Cross Section
 701005 | Sh_2214_lllvjj | 53.1 femto-barn
 
 Make sure to do all calculations in the code; don't do the math in your head. The user may well want to take the code and change some of the parameters.
+
+### Event Scaling and Information on the Plot
+
+When applying this scaling, detail what you are doing in some detail in the notes. On the plot, only put the integrated luminosity you rescaled the MC to (`L=xx $fb^-1$`). Do not mention what scaling was applied, etc., on the plot itself. We want as little possible to detract from the display of the data. If you aren't doing the luminosity rescaling, don't put anything on the plot.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -255,6 +255,8 @@ Always make sure to tell the user what event weights you are applying. If the ab
 
 If any calculations are required (e.g. cross section times integrated luminosity, etc), do them in the code to the user can update things as they wish.
 
+Don't apply any event or sample weights to data unless explicitly requested.
+
 ### MC Event Weight
 
 This is encoded on the `EventInfo` object, and it is the first `mcEventWeight`:
@@ -263,3 +265,24 @@ This is encoded on the `EventInfo` object, and it is the first `mcEventWeight`:
 query = (FuncADLQueryPHYSLITE()
     .Select(lambda e: e.EventInfo("EventInfo").Select(lambda e: e.mcEventWeight(0)
 ```
+
+### Crossection Scaling
+
+Each event in a sample is scaled by a constant scale factor:
+
+$ sf = $ L * \sigma / N_S $
+
+* $L$ - the target integrated luminosity for the plot. Use 1 fempto-barn-1 by default.
+* $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
+* $N_S$ the total number of events in the sample. This must be taken as the total number of events in the file before *any* cuts.
+
+The cross-section table is below, organized by run number and name. Every ATLAS sample is unique by run number, which is in the name of the dataset. For example, "mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697" is an MC dataset with run number 801167 and name Py8EG_A14NNPDF23LO_jj_JZ2 (or JZ2). Data leads with "data..." in the name.
+
+Run Number | Name | Cross Section
+--- | --- | ---
+801167 | Py8EG_A14NNPDF23LO_jj_JZ2 | 2.58 mili-barn
+513109 | MGPy8EG_Zmumu_FxFx3jHT2bias_SW_CFilterBVeto | 2.39 nano-barn
+601237 | PhPy8EG_A14_ttbar_hdamp258p75_allhad | 812 pico-barn
+701005 | Sh_2214_lllvjj | 53.1 fempto-barn
+
+Make sure to do all calculations in the code; don't do the math in your head. The user may well want to take the code and change some of the parameters.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -274,7 +274,7 @@ $ sf = $ L * \sigma / N_S $
 
 * $L$ - the target integrated luminosity for the plot. Use 1 femto-barn-1 by default.
 * $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
-* $N_S$ the total number of events in the sample. This must be taken as the total number of events in the file before *any* cuts. To do this, you should collect a "1" for every event, and then take the len of the array. See below for an example.
+* $N_S$ sum of all the per-event weights (the `mcEventWeight(0)` above). This must be taken as the sum over all events in the file - before *any* cuts. Gather the `mcEventWeight(0)` for all events in the file.
 
 The cross-section table is below, organized by run number and name. Every ATLAS sample is unique by run number, which is in the name of the dataset. For example, "mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697" is an MC dataset with run number 801167 and name Py8EG_A14NNPDF23LO_jj_JZ2 (or JZ2). Data leads with "data..." in the name.
 
@@ -286,14 +286,4 @@ Run Number | Name | Cross Section
 601237 | PhPy8EG_A14_ttbar_hdamp258p75_allhad | 812 pico-barn
 701005 | Sh_2214_lllvjj | 53.1 femto-barn
 
-#### Counting The Sample Size
-
-If you can do something similar to this:
-
-```python
-query = (FuncADLQueryPHYSLITE()
-    .Select(lambda e: 1.0)
-```
-
-And take the `len` of the array when it comes back.
 Make sure to do all calculations in the code; don't do the math in your head. The user may well want to take the code and change some of the parameters.

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -241,7 +241,7 @@ query = (FuncADLQueryPHYSLITE()
     .Select(lambda e: e.Jets().Select(lambda j: jet_is_tagged(j)))
 ```
 
-## Event Weights
+## Event and Sample Weights
 
 Unless otherwise requested by the user, use the following guidelines to determine how to do event weighting:
 

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -274,11 +274,11 @@ The dataset will contain a tag detailing which run you are looking at. We are us
 
 Dataset | Number of Events | Total Luminosity |
 | --- | --- | --- |
-data24_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
-data22_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
-data23_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
-data24_13p6TeV | 2000000000 | 52.4 femto-barns^-1 |
-data25_13p6TeV | 1500000000 | 39.3 femto-barns^-1 |
+data24_13p6TeV | 200000000000000 | 52.4 femto-barns^-1 |
+data22_13p6TeV | 200000000000000 | 52.4 femto-barns^-1 |
+data23_13p6TeV | 200000000000000 | 52.4 femto-barns^-1 |
+data24_13p6TeV | 200000000000000 | 52.4 femto-barns^-1 |
+data25_13p6TeV | 150000000000000 | 39.3 femto-barns^-1 |
 
 ### Cross-section Scaling and MC
 

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -247,8 +247,19 @@ Unless otherwise requested by the user, use the following guidelines to determin
 
 * **Single MC or Data Dataset**: Apply only the MC event weight.
 
-* **Multiple MC Datasets**: Apply the MC event weights, and the cross section. If the cross section weight isn't available for any one sample, then don't apply it for any samples (and make sure to tell the user you are missing that information). The normal way to plot this is with a stacked histogram.
+* **Multiple MC Datasets**: Apply the MC event weights, and the cross section scaling. If the cross section values aren't available for any one sample, then don't apply it for any samples (and make sure to tell the user you are missing that information). The normal way to plot this is with a stacked histogram.
 
 * **MC and Data*: Apply the MC event weights and the cross section, and scale to the integrated luminosity of the data. The normal way to plot this is to use a stacked histogram and the data as a filled black circles.
 
-Always make sure to tell the user what event weights you are applying.
+Always make sure to tell the user what event weights you are applying. If the above guidance tells you to apply event weights but you don't know how, warn the user.
+
+If any calculations are required (e.g. cross section times integrated luminosity, etc), do them in the code to the user can update things as they wish.
+
+### MC Event Weight
+
+This is encoded on the `EventInfo` object, and it is the first `mcEventWeight`:
+
+```python
+query = (FuncADLQueryPHYSLITE()
+    .Select(lambda e: e.EventInfo("EventInfo").Select(lambda e: e.mcEventWeight(0)
+```

--- a/xaod-hints.md
+++ b/xaod-hints.md
@@ -276,6 +276,8 @@ $ sf = $ L * \sigma / N_S $
 * $\sigma$ the cross section of the sample - see below. Doublecheck the units of these numbers! See below for information.
 * $N_S$ sum of all the per-event weights (the `mcEventWeight(0)` above). This must be taken as the sum over all events in the file - before *any* cuts. Gather the `mcEventWeight(0)` for all events in the file.
 
+For a plot, please place the integrated luminosity you rescaled the MC to (`L=xx $fb^-1$`) somewhere on the plot.
+
 The cross-section table is below, organized by run number and name. Every ATLAS sample is unique by run number, which is in the name of the dataset. For example, "mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697" is an MC dataset with run number 801167 and name Py8EG_A14NNPDF23LO_jj_JZ2 (or JZ2). Data leads with "data..." in the name.
 
 Run Number | Name | Cross Section


### PR DESCRIPTION
- Add general guidelines for event weighting based on dataset types.
- Provide explicit instructions for extracting event weights.
- Update cross-section scaling information and clarify calculations.
- Fix typos and improve clarity in documentation regarding event counts and luminosity.
- Include additional data information and refine how information is presented on plots.