### PR TITLE
Add tool initialization and accessor functions

### DIFF
--- a/xaod_hints.py
+++ b/xaod_hints.py
@@ -1,0 +1,130 @@
+import ast
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple, TypeVar
+
+from func_adl import ObjectStream, func_adl_callable
+
+T = TypeVar("T")
+
+
+@dataclass
+class ToolInfo:
+    name: str
+
+
+def make_a_tool(
+    query: ObjectStream[T],
+    tool_name: str,
+    tool_type: str,
+    include_files: Optional[List[str]],
+    init_lines: List[str] = [],
+) -> Tuple[ObjectStream[T], ToolInfo]:
+    """
+    Injects C++ code into the query to initialize a tool of the specified type.
+
+    This function sets up the necessary C++ code to create and initialize a tool (such as
+    BTaggingSelectionTool) in the analysis workflow. The tool will be available in the C++
+    code under the variable name specified by `tool_name`, which can be referenced in
+    initialization lines and later code.
+
+    Args:
+        query: The ObjectStream to attach the tool initialization metadata to.
+        tool_name: The variable name to use for the tool instance in the C++ code.
+        tool_type: The C++ class name of the tool to instantiate.
+        include_files: List of C++ header files to include for the tool.
+        init_lines: List of C++ code lines to run for tool initialization. You can use
+            `{tool_name}` in these lines to refer to the tool variable. You should
+            include the call to `ANA_CHECK({tool_name}->initialize());`.
+
+    Returns:
+        A tuple containing:
+            - The updated ObjectStream with the tool initialization metadata.
+            - A ToolInfo object containing the tool's name. Pass this to `make_tool_accessor`
+    """
+    # Define the C++ for the tool initialization
+
+    query_base = query.MetaData(
+        {
+            "metadata_type": "inject_code",
+            "name": tool_name,
+            "header_includes": include_files,
+            "private_members": [f"{tool_type} *{tool_name};"],
+            "instance_initialization": [
+                f'{tool_name}(new {tool_type} ("{tool_name}"))'
+            ],
+            "initialize_lines": [
+                line.format(tool_name=tool_name) for line in init_lines
+            ],
+            "link_libraries": ["xAODBTaggingEfficiencyLib"],
+        }
+    )
+
+    return query_base, ToolInfo(name=tool_name)
+
+
+def make_tool_accessor(
+    t_info: ToolInfo,
+    function_name: str,
+    source_code: List[str],
+    arguments: Iterable[Tuple[str, type]],
+    return_type_cpp: str,
+    return_type_python: str,
+):
+    """
+    Creates a Python-callable accessor for a C++ tool in the func_adl query.
+
+    This function generates a Python function that, when called in a func_adl query,
+    injects C++ code to call a method or function on a C++ tool instance (such as
+    BTaggingSelectionTool). The accessor function can be used in the query to access
+    tool functionality as if it were a regular Python function.
+
+    Args:
+        t_info: ToolInfo object containing the tool's variable name.
+        function_name: Name of the accessor function (used in C++ and Python).
+        source_code: List of C++ code lines to execute for the accessor. You can use
+            `{tool_name}` in these lines to refer to the tool variable.
+        arguments: Iterable of (argument_name, type) tuples specifying the arguments
+            for the accessor function.
+        return_type_cpp: The C++ return type of the accessor function.
+        return_type_python: The Python return type annotation as a string.
+
+    Returns:
+        A Python function that can be used in a func_adl query to access the tool.
+        NOTE: YOU MUST use the same name as `function_name` to store this:
+
+            `my_name = make_tool_accessor(.., function_name="my_name", ...)`
+    """
+
+    # Define the callback function that `func_adl` will use to inject the calling code.
+    def tool_callback(
+        s: ObjectStream[T], a: ast.Call
+    ) -> Tuple[ObjectStream[T], ast.Call]:
+        new_s = s.MetaData(
+            {
+                "metadata_type": "add_cpp_function",
+                "name": function_name,
+                "code": [
+                    "double result;",
+                    *[line.format(tool_name=t_info.name) for line in source_code],
+                ],
+                "result": "result",
+                "include_files": [],
+                "arguments": [a[0] for a in arguments],
+                "return_type": return_type_cpp,
+            }
+        )
+        return new_s, a
+
+    # Build a function type-shed that tells `func_adl` what the function signature is.
+    # This is used to generate the correct C++ code for the function.
+    def tool_call(**arg_dict):
+        """
+        NOTE: This is a dummy function that injects C++ into the object stream to do the
+        actual work.
+        """
+        ...
+
+    tool_call.__name__ = function_name
+    tool_call.__annotations__["return"] = eval(return_type_python)
+
+    return func_adl_callable(tool_callback)(tool_call)


### PR DESCRIPTION
Take advange of the new hint file includes so that we reduce the "copy" load on LLM's (and reduce the size of the context).

- Introduce `make_a_tool` function to inject C++ code for tool initialization.
- Implement `make_tool_accessor` function to create Python-callable accessors for C++ tools.
- Update documentation to clarify usage of `BTaggingSelectionTool` and working points.