### PR TITLE
Enhance ServiceX and RDF integration documentation

### DIFF
--- a/rdf-hints.md
+++ b/rdf-hints.md
@@ -1,0 +1,3 @@
+# ROOT's RDataFrame
+
+Use the PyROOT interface to build RDataFrame (RDF) pipelines. Complex manipulations may require C++ code injection as arguments to RDF pipeline primitives.

--- a/rdf-hints.md
+++ b/rdf-hints.md
@@ -1,3 +1,16 @@
 # ROOT's RDataFrame
 
 Use the PyROOT interface to build RDataFrame (RDF) pipelines. Complex manipulations may require C++ code injection as arguments to RDF pipeline primitives.
+
+Try not to code everything in C++, rather code in steps, defining variables with `Declare` that get combined or cut on. Some complex variables may need to be defined by C++, of course.
+
+* Use `<source>.Declare` function to define new variables in the RDF
+* Use `<source>.Filter` function to filter
+* Use `<source>.Histo1D` and `2D` and `3D` functions to define histograms.
+
+Also, you can use in other places
+
+* Use `.Count` function to count (say, number of jets)
+* Use `Max`, `Mean`, and `Min` functions as needed.
+
+When you do have to declare C++ functions (with `ROOT.gInterpreter.Declare`) try to make sure they functions follow good engineering principles - so, for example, no duplicated code.

--- a/servicex-awk-hints.md
+++ b/servicex-awk-hints.md
@@ -1,0 +1,14 @@
+# Extracting awkward array data from ServiceX
+
+Use the `to_awk` function on the result of the `deliver` call to convert the dictionary of results into a dictionary of `awkward` arrays.
+
+Continuing the example from the `servicex` section above:
+
+```python
+from servicex_analysis_utils import to_awk
+
+all_jets_pts_awk = to_awk(all_jet_pts_delivered)
+jet_pts = all_jets_pts_awk["jet_pt_fetch"]
+```
+
+And `jet_pts.jet_pt` is a awkward array of jets $p_T$'s. where `jet_pt` comes from the query dictionary.

--- a/servicex-hints.md
+++ b/servicex-hints.md
@@ -6,7 +6,7 @@ Fetching data is two steps. First, construct a query. Second, execute the query 
 
 Notes:
 
-* Moving data out of ServiceX and into awkward arrays is expensive. If there is something you can do to reduce the amount of data out of ServiceX it is worth doing it. For example, if you know that you'll never use jets with less than 40 GeV, you can filter jets at the ServiceX level.
+* Moving data out of ServiceX is expensive. If there is something you can do to reduce the amount of data out of ServiceX it is worth doing it. For example, if you know that you'll never use jets with less than 40 GeV, you can filter jets at the ServiceX level.
 * Quantities returned from servicex should be in units most people use at the LHC - GeV, meters, etc. Please convert from whatever the units of the input files are.
 
 ## A Simple Full Example
@@ -91,7 +91,7 @@ Notes:
 
 * If you have flattened a variable like this, you'll get an unnested array.
 
-*(The above returns an Awkward Array of jet $p_T$ values under the key `pt`.)*
+*(The above returns an Array of jet $p_T$ values under the key `pt`.)*
 
 ## Selecting Nested Data per Event
 
@@ -123,7 +123,7 @@ query = jets_per_event.Select(lambda jets: jets.Select(lambda j:  # WILL NOT WOR
 
 Nor can you have nested dictionaries.
 
-*Each event in the resulting Awkward Array has a list of events, each with a list of jet $p_T$ and $\eta$ values.*
+*Each event in the resulting Array has a list of events, each with a list of jet $p_T$ and $\eta$ values.*
 
 ## Filtering Objects in a Query
 
@@ -177,7 +177,7 @@ query = (FuncADLQueryPHYSLITE()
     })
 ```
 
-*Here `pairs.ele` and `pairs.mu` refer to the Electron and Muon lists respectively. The result contains four Awkward Array fields: electron $p_T$, electron $\eta$, muon $p_T$, muon $\eta$ for each event.*
+*Here `pairs.ele` and `pairs.mu` refer to the Electron and Muon lists respectively. The result contains four Array fields: electron $p_T$, electron $\eta$, muon $p_T$, muon $\eta$ for each event.*
 
 Filtering objects is often most easily done at this level as well, as it means putting the filter in only once:
 

--- a/servicex-hints.md
+++ b/servicex-hints.md
@@ -15,7 +15,6 @@ This example fetches the jet $p_T$'s from a PHYSLITE formatted xAOD data sample 
 
 ```python
 from func_adl_servicex_xaodr25 import FuncADLQueryPHYSLITE
-from servicex_analysis_utils import to_awk
 from servicex import deliver, ServiceXSpec, Sample, dataset
 
 # The base query should run against PHYSLITE.
@@ -33,35 +32,30 @@ jet_pts_query = (base_query
 # Define the rucio dataset identifier (DID).
 ds_name = ("mc23_13p6TeV:mc23_13p6TeV.801167.Py8EG_A14NNPDF23LO_jj_JZ2.deriv.DAOD_PHYSLITE.e8514_e8528_a911_s4114_r15224_r15225_p6697")
 
-all_jet_pts = to_awk(
-    deliver(
-        ServiceXSpec(
-            Sample=[
-                Sample(
-                    Name="jet_pt_fetch",
-                    Dataset=dataset.Rucio(ds_name),
-                    NFiles=1,
-                    Query=jet_pts_query,
-                )
-            ]
-        ),
-    )
+all_jet_pts_delivered = deliver(
+    ServiceXSpec(
+        Sample=[
+            Sample(
+                Name="jet_pt_fetch",
+                Dataset=dataset.Rucio(ds_name),
+                NFiles=1,
+                Query=jet_pts_query,
+            )
+        ]
+    ),
 )
-
-data = all_jet_pts["jet_pt_fetch"]
 ```
 
-`all_jet_pts` is a dictionary indexed by the `Sample` `Name`. And `all_jet_pts["jet_pt_fetch"].jet_pt` is a awkward array of jets $p_T$'s.
+`all_jet_pts` is a dictionary indexed by the `Sample` `Name`. It contains points to one or more root files that contain the data from each `Sample`.
 
-Make sure to copy over the dataset name the user has requested into `ds_name` carefully! If it isn't right then ServiceX fails with a odd error.
+Make sure to copy over the dataset name the user has requested into `ds_name` carefully! If it isn't right then ServiceX fails with a odd error!
 
 ## The `deliver` function
 
 * Always use `NFiles=1` as above, even if the user asks otherwise. If they do, tell them they can run it themselves when they are ready!
 * The query can be re-used.
 * Use `dataset.Rucio` for a `rucio` dataset, use `dataset.FileList` for a list of web accessible datasets (via `https` or `xrootd://`)
-* Only call deliver once - make sure all the data you want is in the query.
-* Do not accept a query that requires multiple datasets.
+* Only call deliver once - make sure all the data you want is in the query, even if multiple samples.
 
 ## Queries
 

--- a/servicex-rdf-hints.md
+++ b/servicex-rdf-hints.md
@@ -1,0 +1,20 @@
+# Loading ServiceX Results into RDF
+
+The `all_jet_pts_delivered` contains a set of files that can be turned into a RDF source. Assume
+the ServiceX query result is stored in `all_jet_pts_delivered`, as it in the example above.
+
+```python
+import ROOT
+
+# Load the ROOT file and create a DataFrame from the tree
+# ServiceX always writes a tree with the name `tree`.
+df = ROOT.RDataFrame("tree", all_jet_pts_delivered['jet_pt_fetch'])
+
+# Create a histogram of the 'jet_pt' branch
+hist = df.Histo1D(("jet_pt_hist", "Jet pT", 100, 0, 500), "jet_pt")
+
+# Draw the histogram
+canvas = ROOT.TCanvas()
+hist.Draw()
+canvas.SaveAs("jet_pt_hist.png")  # Save to file```
+```

--- a/servicex-rdf-hints.md
+++ b/servicex-rdf-hints.md
@@ -7,8 +7,8 @@ the ServiceX query result is stored in `all_jet_pts_delivered`, as it in the exa
 import ROOT
 
 # Load the ROOT file and create a DataFrame from the tree
-# ServiceX always writes a tree with the name `tree`.
-df = ROOT.RDataFrame("tree", all_jet_pts_delivered['jet_pt_fetch'])
+# ServiceX always writes a tree with the name `atlas_xaod_tree`.
+df = ROOT.RDataFrame("atlas_xaod_tree", all_jet_pts_delivered['jet_pt_fetch'])
 
 # Create a histogram of the 'jet_pt' branch
 hist = df.Histo1D(("jet_pt_hist", "Jet pT", 100, 0, 500), "jet_pt")


### PR DESCRIPTION
- Introduce the initial version of the documentation for RDataFrame (RDF) pipelines.
- Reduce the frequency of "awkward" mentions for clarity.
- Clarify the usage of ServiceX and awkward arrays.
- Provide detailed instructions for loading ServiceX results into RDF.
- Improve examples and explanations related to data handling and filtering.